### PR TITLE
DEV: Update linting setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  rubocop-discourse: stree-compat.yml

--- a/.streerc
+++ b/.streerc
@@ -1,0 +1,2 @@
+--print-width=100
+--plugins=plugin/trailing_comma,plugin/disable_auto_ternary

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+group :development do
+  gem "rubocop-discourse"
+  gem "syntax_tree"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,87 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.2.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.6)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    logger (1.6.1)
+    minitest (5.25.1)
+    parallel (1.26.3)
+    parser (3.3.5.0)
+      ast (~> 2.4.1)
+      racc
+    prettier_print (1.2.1)
+    racc (1.8.1)
+    rack (3.1.8)
+    rainbow (3.1.1)
+    regexp_parser (2.9.2)
+    rubocop (1.67.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.3)
+      parser (>= 3.3.1.0)
+    rubocop-capybara (2.21.0)
+      rubocop (~> 1.41)
+    rubocop-discourse (3.8.2)
+      activesupport (>= 6.1)
+      rubocop (>= 1.59.0)
+      rubocop-capybara (>= 2.0.0)
+      rubocop-factory_bot (>= 2.0.0)
+      rubocop-rails (>= 2.25.0)
+      rubocop-rspec (>= 3.0.1)
+      rubocop-rspec_rails (>= 2.30.0)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
+    rubocop-rails (2.26.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (3.1.0)
+      rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
+    ruby-progressbar (1.13.0)
+    securerandom (0.3.1)
+    syntax_tree (6.2.0)
+      prettier_print (>= 1.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  rubocop-discourse
+  syntax_tree
+
+BUNDLED WITH
+   2.5.21

--- a/javascripts/discourse/lib/resize-tester.js
+++ b/javascripts/discourse/lib/resize-tester.js
@@ -1,6 +1,6 @@
 import { handlerRectangles } from "./handler-rectangles";
 
-export function resizeTest(element, x, y, { scrollX, scrollY }) {
+export function resizeTester(element, x, y, { scrollX, scrollY }) {
   if (!element.isSelected || element.type === "text") {
     return false;
   }
@@ -34,7 +34,7 @@ export function getElementWithResizeHandler(
     if (result) {
       return result;
     }
-    const resizeHandle = resizeTest(element, x, y, {
+    const resizeHandle = resizeTester(element, x, y, {
       scrollX,
       scrollY,
     });

--- a/javascripts/discourse/widgets/discourse-sketch.js
+++ b/javascripts/discourse/widgets/discourse-sketch.js
@@ -12,7 +12,7 @@ import {
 import {
   getCursorForResizingElement,
   getElementWithResizeHandler,
-} from "../lib/resize-test";
+} from "../lib/resize-tester";
 import { renderScene } from "../lib/scene";
 import { defaultSketchState } from "../lib/sketch-state";
 import { applyPixelRatio, getElementAtPosition } from "../lib/utils";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "@discourse/lint-configs": "1.3.10",
+    "@discourse/lint-configs": "1.4.2",
     "ember-template-lint": "6.0.0",
     "eslint": "8.57.1",
     "prettier": "2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.25.7
         version: 7.25.7(@babel/core@7.25.8)
       '@discourse/lint-configs':
-        specifier: 1.3.10
-        version: 1.3.10(ember-template-lint@6.0.0)(eslint@8.57.1)(prettier@2.8.8)
+        specifier: 1.4.2
+        version: 1.4.2(ember-template-lint@6.0.0)(eslint@8.57.1)(prettier@2.8.8)
       ember-template-lint:
         specifier: 6.0.0
         version: 6.0.0
@@ -152,11 +152,11 @@ packages:
     resolution: {integrity: sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==}
     engines: {node: '>=6.9.0'}
 
-  '@discourse/lint-configs@1.3.10':
-    resolution: {integrity: sha512-PQ56xx4UfceLR/wJm7ig1JRNKkLVYPAeyp5bV6k6jQhpVr9TeZdobeCfGbVtKG6hhuaQ4aECPjRf/MoNw00/cw==}
+  '@discourse/lint-configs@1.4.2':
+    resolution: {integrity: sha512-AhwEfqy7ByheuNEhioXlkcgrbvzQY8yFbSWwtqAB0GXsp4UNaMZFyjdMoPFgaUDdUzjY/eKFFZ/j4FkA9EY4qA==}
     peerDependencies:
       ember-template-lint: 6.0.0
-      eslint: 8.57.0
+      eslint: 8.57.1
       prettier: 2.8.8
 
   '@ember-data/rfc395-data@0.0.4':
@@ -1947,7 +1947,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
-  '@discourse/lint-configs@1.3.10(ember-template-lint@6.0.0)(eslint@8.57.1)(prettier@2.8.8)':
+  '@discourse/lint-configs@1.4.2(ember-template-lint@6.0.0)(eslint@8.57.1)(prettier@2.8.8)':
     dependencies:
       '@babel/core': 7.25.8
       '@babel/eslint-parser': 7.25.8(@babel/core@7.25.8)(eslint@8.57.1)


### PR DESCRIPTION
This PR enables and resolves linting.

Renamed resize-test to resize-tester as eslint recognises that file as a test file (which it isn't).